### PR TITLE
fix: site feed returns 404

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem "bridgetown", "~> 0.20.0"
 
-gem "bulmatown", "~> 1.1", :group => :bridgetown_plugins
-
-gem "bridgetown-quick-search", "~> 1.0", :group => :bridgetown_plugins
+group :bridgetown_plugins do
+  gem "bulmatown", "~> 1.1"
+  gem "bridgetown-quick-search", "~> 1.0"
+  gem "bridgetown-feed",  "~> 2.0"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,13 @@ group :bridgetown_plugins do
   gem "bridgetown-quick-search", "~> 1.0"
   gem "bridgetown-feed",  "~> 2.0"
 end
+
+
+group :test, optional: true do
+  gem "nokogiri"
+  gem "minitest"
+  gem "minitest-profile"
+  gem "minitest-reporters"
+  gem "shoulda"
+  gem "rails-dom-testing"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     amazing_print (1.3.0)
+    ansi (1.5.0)
     bridgetown (0.20.0)
       bridgetown-builder (= 0.20.0)
       bridgetown-core (= 0.20.0)
@@ -46,6 +47,7 @@ GEM
       bridgetown-core (= 0.20.0)
     bridgetown-quick-search (1.0.5)
       bridgetown (>= 0.15.0.beta1, < 2.0)
+    builder (3.2.4)
     bulmatown (1.1.0)
       bridgetown (>= 0.15, < 2.0)
       bridgetown-quick-search (~> 1.0)
@@ -80,15 +82,36 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     minitest (5.14.4)
+    minitest-profile (0.0.2)
+    minitest-reporters (1.4.3)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     multipart-post (2.1.1)
+    nokogiri (1.11.7-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.11.7-x86_64-linux)
+      racc (~> 1.4)
     public_suffix (4.0.6)
+    racc (1.5.2)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
     rouge (3.26.0)
+    ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
     safe_yaml (1.0.5)
+    shoulda (4.0.0)
+      shoulda-context (~> 2.0)
+      shoulda-matchers (~> 4.0)
+    shoulda-context (2.0.0)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (1.1.0)
@@ -108,6 +131,12 @@ DEPENDENCIES
   bridgetown-feed (~> 2.0)
   bridgetown-quick-search (~> 1.0)
   bulmatown (~> 1.1)
+  minitest
+  minitest-profile
+  minitest-reporters
+  nokogiri
+  rails-dom-testing
+  shoulda
 
 BUNDLED WITH
    2.2.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       thor (~> 1.1)
       tilt (~> 2.0)
       webrick (~> 1.7)
+    bridgetown-feed (2.0.1)
+      bridgetown (>= 0.20, < 2.0)
     bridgetown-paginate (0.20.0)
       bridgetown-core (= 0.20.0)
     bridgetown-quick-search (1.0.5)
@@ -99,9 +101,11 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   bridgetown (~> 0.20.0)
+  bridgetown-feed (~> 2.0)
   bridgetown-quick-search (~> 1.0)
   bulmatown (~> 1.1)
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "webpack-dev": "webpack --mode development -w",
     "deploy": "yarn clean && yarn webpack-build && yarn build",
     "sync": "node sync.js",
-    "start": "node start.js"
+    "start": "node start.js",
+    "test": "BRIDGETOWN_ENV=test yarn build",
+    "deploy:test": "bundle install --with test && yarn deploy"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/plugins/test_output.rb
+++ b/plugins/test_output.rb
@@ -1,0 +1,9 @@
+unless Bridgetown.environment == "development"
+  Bridgetown::Hooks.register :site, :post_write do
+    # Load test suite to run on exit
+    require "nokogiri"
+    Dir["test/**/*.rb"].each { |file| require_relative("../#{file}") }
+  rescue LoadError
+    Bridgetown.logger.warn "Testing:", "To run tests, you must first run `bundle install --with test`"
+  end
+end

--- a/src/_components/head.liquid
+++ b/src/_components/head.liquid
@@ -4,6 +4,6 @@
 <title>{% if page_title != "" %}{{ page_title | escape }} | {{ metadata.title | escape }}{% else %}{{ metadata.title | escape }}: {{ metadata.tagline | escape }}{% endif %}</title>
 
 <meta name="description" content="{{ metadata.description }}" />
-
+{% feed_meta %}
 <link rel="stylesheet" href="{% webpack_path css %}" />
 <script src="{% webpack_path js %}" defer></script>

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,30 @@
+require "nokogiri"
+require "minitest/autorun"
+require "minitest/reporters"
+require "minitest/profile"
+require "shoulda"
+require "rails-dom-testing"
+# Report with color.
+Minitest::Reporters.use! [
+  Minitest::Reporters::DefaultReporter.new(
+    color: true
+  ),
+]
+Minitest::Test.class_eval do
+  include Rails::Dom::Testing::Assertions
+  def site
+    @site ||= Bridgetown.sites.first
+  end
+  def nokogiri(input)
+    input.respond_to?(:output) ? Nokogiri::HTML(input.output) : Nokogiri::HTML(input)
+  end
+  def document_root(root)
+    @document_root = root.is_a?(Nokogiri::XML::Document) ? root : nokogiri(root)
+  end
+  def document_root_element
+    if @document_root.nil?
+      raise "Call `document_root' with a Nokogiri document before testing your assertions"
+    end
+    @document_root
+  end
+end

--- a/test/test_feed.rb
+++ b/test/test_feed.rb
@@ -1,0 +1,14 @@
+require_relative "./helper"
+class TestFeed < Minitest::Test
+  context "feed" do
+    setup do
+      @page = site.pages.find { |doc| doc.url == "/feed.xml" }
+    end
+    should "exist" do
+      assert @page.present?
+      # The feed should not render with a
+      # layout since it is just a text document.
+      assert @page.no_layout?
+    end
+  end
+end


### PR DESCRIPTION
In its current state, the site does not generate a RSS feed, but the footer still links to one. This PR resolves that issue and generates a valid feed at `/feed.xml` with the correct headers.

1. The first commit installs [bridgetownrb/bridgetown-feed: A Bridgetown plugin to generate an Atom feed of your Bridgetown posts](https://github.com/bridgetownrb/bridgetown-feed) and follows the instructions in the docs to add `{% feed_meta %}` in the head of the document.

2. The second commit is totally optional and can be removed if it is undesired but it uses the minitest [bundled configuration](https://www.bridgetownrb.com/docs/bundled-configurations) (`bundle exec bridgetown configure minitesting`) to create a test setup and adds a simple test to verify the feed is now being generated. Do note that you will have to run `bundle install --with test` in order to run the tests via `yarn test`.